### PR TITLE
Add support for JS files on TS projects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,13 @@
 {
-  "parser": "@typescript-eslint/parser",
   "plugins": [
     "self",
     "eslint-plugin"
   ],
   "extends": [
-    "plugin:self/typescript",
-    "plugin:eslint-plugin/recommended"
+    "plugin:eslint-plugin/recommended",
+    "plugin:self/typescript"
   ],
   "parserOptions": {
-    "extends": "./tsconfig.json",
-    "project": ["./tsconfig.json"]
+      "project": ["**/tsconfig.json"]
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,17 +27,19 @@ To enable this preset, add the following to your `.eslintrc` file:
 
 Enforces Croct's standard TypeScript best practices.
 
-To enable this preset, add the following to your `.eslintrc` file:
+To enable this preset, add the following to your `.eslintrc.js` file:
 
-```json
-{
-  "plugins": [
-    "@croct"
-  ],
-  "extends": [
-    "plugin:@croct/typescript"
-  ]
-}
+```js
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-patch/modern-module-resolution');
+
+module.exports = {
+    plugins: ['@croct'],
+    extends: ['plugin:@croct/typescript'],
+    parserOptions: {
+        project: ['**/tsconfig.json'],
+    },
+};
 ```
 
 This preset extends the JavaScript preset – no need to include it as well.

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -1,93 +1,80 @@
 export const typescript = {
-    extends: [
-        'plugin:@typescript-eslint/recommended',
-        'plugin:@croct/javascript',
-    ],
-    plugins: [
-        '@typescript-eslint',
-        '@croct',
-    ],
-    rules: {
-        '@typescript-eslint/array-type': [
-            'error',
-            {
-                default: 'array-simple',
-            },
-        ],
-        '@typescript-eslint/prefer-as-const': 'error',
-        '@typescript-eslint/adjacent-overload-signatures': 'error',
-        '@typescript-eslint/type-annotation-spacing': 'error',
-        '@typescript-eslint/semi': ['error', 'always'],
-        '@typescript-eslint/strict-boolean-expressions': [
-            'error',
-            {
-                allowString: false,
-                allowNumber: false,
-                allowNullableObject: false,
-            },
-        ],
-        '@typescript-eslint/prefer-regexp-exec': 'error',
-        '@typescript-eslint/prefer-optional-chain': 'error',
-
-        'no-shadow': 'off',
-        '@typescript-eslint/no-shadow': [
-            'error',
-            {
-                ignoreTypeValueShadow: true,
-                ignoreFunctionTypeParameterNameValueShadow: true,
-            },
-        ],
-        '@typescript-eslint/no-empty-interface': 'off',
-        '@typescript-eslint/explicit-member-accessibility': [
-            'error',
-        ],
-        '@typescript-eslint/explicit-module-boundary-types': 'off',
-        '@typescript-eslint/explicit-function-return-type': [
-            'error',
-        ],
-        '@typescript-eslint/no-explicit-any': 'off',
-        'no-use-before-define': 'off',
-        '@typescript-eslint/no-use-before-define': 'error',
-        'no-unused-expressions': 'off',
-        '@typescript-eslint/no-unused-expressions': 'error',
-        indent: [
-            'error',
-            4,
-            {
-                SwitchCase: 1,
-            },
-        ],
-        '@typescript-eslint/no-unused-vars': 'error',
-        'no-unused-vars': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-        'object-curly-spacing': 'off',
-        '@typescript-eslint/object-curly-spacing': 'error',
-        '@typescript-eslint/member-delimiter-style': [
-            'error',
-            {
-                multiline: {
-                    delimiter: 'comma',
-                    requireLast: true,
-                },
-                singleline: {
-                    delimiter: 'comma',
-                    requireLast: false,
-                },
-                overrides: {
-                    interface: {
-                        singleline: {
-                            delimiter: 'semi',
-                        },
-                        multiline: {
-                            delimiter: 'semi',
+    extends: ['plugin:@croct/javascript'],
+    plugins: ['@croct'],
+    overrides: [
+        {
+            files: ['**/*.ts', '**/*.tsx'],
+            extends: [
+                'plugin:@typescript-eslint/recommended',
+                'plugin:@croct/javascript',
+            ],
+            plugins: [
+                '@typescript-eslint',
+                '@croct',
+            ],
+            parser: '@typescript-eslint/parser',
+            rules: {
+                '@typescript-eslint/array-type': ['error', {
+                    default: 'array-simple',
+                }],
+                '@typescript-eslint/prefer-as-const': 'error',
+                '@typescript-eslint/adjacent-overload-signatures': 'error',
+                '@typescript-eslint/type-annotation-spacing': 'error',
+                '@typescript-eslint/semi': ['error', 'always'],
+                '@typescript-eslint/strict-boolean-expressions': ['error', {
+                    allowString: false,
+                    allowNumber: false,
+                    allowNullableObject: false,
+                }],
+                '@typescript-eslint/prefer-regexp-exec': 'error',
+                '@typescript-eslint/prefer-optional-chain': 'error',
+                'no-shadow': 'off',
+                '@typescript-eslint/no-shadow': ['error', {
+                    ignoreTypeValueShadow: true,
+                    ignoreFunctionTypeParameterNameValueShadow: true,
+                }],
+                '@typescript-eslint/no-empty-interface': 'off',
+                '@typescript-eslint/explicit-member-accessibility': [
+                    'error',
+                ],
+                '@typescript-eslint/explicit-module-boundary-types': 'off',
+                '@typescript-eslint/explicit-function-return-type': ['error'],
+                '@typescript-eslint/no-explicit-any': 'off',
+                'no-use-before-define': 'off',
+                '@typescript-eslint/no-use-before-define': 'error',
+                'no-unused-expressions': 'off',
+                '@typescript-eslint/no-unused-expressions': 'error',
+                indent: ['error', 4, {
+                    SwitchCase: 1,
+                }],
+                '@typescript-eslint/no-unused-vars': 'error',
+                'no-unused-vars': 'off',
+                '@typescript-eslint/no-non-null-assertion': 'off',
+                'object-curly-spacing': 'off',
+                '@typescript-eslint/object-curly-spacing': 'error',
+                '@typescript-eslint/member-delimiter-style': ['error', {
+                    multiline: {
+                        delimiter: 'comma',
+                        requireLast: true,
+                    },
+                    singleline: {
+                        delimiter: 'comma',
+                        requireLast: false,
+                    },
+                    overrides: {
+                        interface: {
+                            singleline: {
+                                delimiter: 'semi',
+                            },
+                            multiline: {
+                                delimiter: 'semi',
+                            },
                         },
                     },
-                },
+                }],
+                'no-undef': 'off',
             },
-        ],
-        'no-undef': 'off',
-    },
-    overrides: [
+        },
         {
             files: [
                 'src/**/*.test.ts',

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -1,17 +1,13 @@
 export const typescript = {
     extends: ['plugin:@croct/javascript'],
-    plugins: ['@croct'],
+    plugins: [
+        '@typescript-eslint',
+        '@croct',
+    ],
     overrides: [
         {
             files: ['**/*.ts', '**/*.tsx'],
-            extends: [
-                'plugin:@typescript-eslint/recommended',
-                'plugin:@croct/javascript',
-            ],
-            plugins: [
-                '@typescript-eslint',
-                '@croct',
-            ],
+            extends: ['plugin:@typescript-eslint/recommended'],
             parser: '@typescript-eslint/parser',
             rules: {
                 '@typescript-eslint/array-type': ['error', {


### PR DESCRIPTION
## Summary
With this change the `@croct/typescript` preset will set typescript rules only for `.ts` and `.tsx` files, `.js` and `.jsx` files will continue to be validated using the `@croct/javascript` preset.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings