### PR TITLE
Disable linter `prefer-regex-exec`

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -22,7 +22,7 @@ export const typescript = {
                     allowNumber: false,
                     allowNullableObject: false,
                 }],
-                '@typescript-eslint/prefer-regexp-exec': 'error',
+                '@typescript-eslint/prefer-regexp-exec': 'off',
                 '@typescript-eslint/prefer-optional-chain': 'error',
                 'no-shadow': 'off',
                 '@typescript-eslint/no-shadow': ['error', {


### PR DESCRIPTION
## Summary
The autofix from `String.match` to `RegExp.exec` may introduce bugs when the linter cannot correctly infer the flags of the expression to ensure it remains stateless

Example where the flag is not inferred:

```ts
export class Foo
    private static VALIDATION_REGEX = /something/g; // Should be inferred as statefull

    public validate(value: string): void {
        // This match should be replaced by `.exec` since it will make consecutive calls to this method break,
        // but the linter cannot infer this correctly and does the change automatically
        if (value.match(Foo.VALIDATION_REGEX) == null) {
            // So something with instance variables
        }
    }
}
```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings