### PR TITLE
Remove rule @typescript-eslint/prefer-regexp-exec

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -22,7 +22,6 @@ export const typescript = {
                     allowNumber: false,
                     allowNullableObject: false,
                 }],
-                '@typescript-eslint/prefer-regexp-exec': 'off',
                 '@typescript-eslint/prefer-optional-chain': 'error',
                 'no-shadow': 'off',
                 '@typescript-eslint/no-shadow': ['error', {


### PR DESCRIPTION
## Summary

The rule is not required to be explicit "off" since it's not included by default on the `@typescript-eslint/recommended`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings