### PR TITLE
Add rule newline-per-chained-call

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,9 +86,9 @@ This preset extends the JavaScript preset – no need to include it as well.
 
 The plugin also ships with a few custom ESLint rules, all enabled by default in the related preset.
 
-| Rule                                                              | Description                                                                                         |
-|-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-| [argument-spacing](rules/argument-spacing.md)                     | Enforces a surrounding line break before and after the argument list in multiline functional calls. |
-| [new-per-chained-call](rules/newline-per-chained-call)            | Enforces a surrounding line break in multiline JSX attributes.                                      |
-| [complex-expression-spacing](rules/complex-expression-spacing.md) | Enforces a surrounding line break in complex expression.                                            |
-| [jsx-attribute-spacing](rules/jsx-attribute-spacing.md)           | Enforces a surrounding line break in multiline JSX attributes.                                      |
+| Rule                                                              | Description                                                    |
+|-------------------------------------------------------------------|----------------------------------------------------------------|
+| [argument-spacing](rules/argument-spacing.md)                     | Enforces a newline before chained calls.                       |
+| [new-per-chained-call](rules/newline-per-chained-call)            | Enforces a surrounding line break in multiline JSX attributes. |
+| [complex-expression-spacing](rules/complex-expression-spacing.md) | Enforces a surrounding line break in complex expression.       |
+| [jsx-attribute-spacing](rules/jsx-attribute-spacing.md)           | Enforces a surrounding line break in multiline JSX attributes. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,5 +89,6 @@ The plugin also ships with a few custom ESLint rules, all enabled by default in 
 | Rule                                                              | Description                                                                                         |
 |-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 | [argument-spacing](rules/argument-spacing.md)                     | Enforces a surrounding line break before and after the argument list in multiline functional calls. |
+| [new-per-chained-call](rules/newline-per-chained-call)            | Enforces a surrounding line break in multiline JSX attributes.                                      |
 | [complex-expression-spacing](rules/complex-expression-spacing.md) | Enforces a surrounding line break in complex expression.                                            |
 | [jsx-attribute-spacing](rules/jsx-attribute-spacing.md)           | Enforces a surrounding line break in multiline JSX attributes.                                      |

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,9 +86,9 @@ This preset extends the JavaScript preset – no need to include it as well.
 
 The plugin also ships with a few custom ESLint rules, all enabled by default in the related preset.
 
-| Rule                                                              | Description                                                    |
-|-------------------------------------------------------------------|----------------------------------------------------------------|
-| [argument-spacing](rules/argument-spacing.md)                     | Enforces a newline before chained calls.                       |
-| [new-per-chained-call](rules/newline-per-chained-call)            | Enforces a surrounding line break in multiline JSX attributes. |
-| [complex-expression-spacing](rules/complex-expression-spacing.md) | Enforces a surrounding line break in complex expression.       |
-| [jsx-attribute-spacing](rules/jsx-attribute-spacing.md)           | Enforces a surrounding line break in multiline JSX attributes. |
+| Rule                                                              | Description                                                                                         |
+|-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| [newline-per-chained-call](rules/newline-per-chained-call.md)     | Enforces a newline before chained calls.                                                            |
+| [argument-spacing](rules/argument-spacing.md)                     | Enforces a surrounding line break before and after the argument list in multiline functional calls. |
+| [complex-expression-spacing](rules/complex-expression-spacing.md) | Enforces a surrounding line break in complex expression.                                            |
+| [jsx-attribute-spacing](rules/jsx-attribute-spacing.md)           | Enforces a surrounding line break in multiline JSX attributes.                                      |

--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -1,6 +1,6 @@
 # `newline-per-chained-call`
 
-Requires a newline before each chained method call after reaching a configurable maximum depth.
+Enforces a newline before each chained method call after reaching a configurable maximum depth.
 
 ## Rule details
 

--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -1,0 +1,83 @@
+# `newline-per-chained-call`
+
+Require a newline after each function call in a method chain.
+
+## Rule details
+
+This rule complements the [`newline-per-chained-call`](https://eslint.org/docs/rules/newline-per-chained-call)
+to enforce a new line after each chained function call, and also changing the ignoreChainWithDepth 
+behavior to break chained calls recursively when the limit is reached.
+
+## How to use
+
+```json
+{
+  "@croct/newline-per-chained-call": [
+    "error",
+    {
+      "ignoreChainWithDepth": 2
+    }
+  ]
+}
+```
+
+## Examples
+
+These are examples of how the rule might apply.
+
+### ❌ Incorrect
+
+```jsx
+foo().bar().baz().qux();
+```
+
+```jsx
+foo.bar.baz.qux();
+```
+
+### ✅ Correct
+
+```jsx
+foo()
+    .bar()
+    .baz()
+    .qux();
+```
+
+```jsx
+await expect(callback).resolves.toHaveBeenCalledWith();
+```
+
+```jsx
+foo.bar.baz.qux;
+```
+
+## Options
+
+This rule has no configuration options.
+
+* "ignoreChainWithDepth" (default: 2) allows chains up to a specified depth.
+
+### ignoreChainWithDepth
+
+#### ❌ Incorrect
+
+```jsx
+/*eslint newline-per-chained-call: ["error", { "ignoreChainWithDepth": 1 }]*/
+foo().bar().baz();
+```
+
+#### ✅ Correct
+
+```jsx
+/*eslint newline-per-chained-call: ["error", { "ignoreChainWithDepth": 1 }]*/
+foo()
+    .bar()
+    .baz();
+```
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [x] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -1,12 +1,12 @@
 # `newline-per-chained-call`
 
-Require a newline after each function call in a method chain.
+Requires a newline before each chained method call after reaching a configurable maximum depth.
 
 ## Rule details
 
-This rule complements the [`newline-per-chained-call`](https://eslint.org/docs/rules/newline-per-chained-call)
-to enforce a new line after each chained function call, and also changing the ignoreChainWithDepth 
-behavior to break chained calls recursively when the limit is reached.
+This rule differs from the [`newline-per-chained-call`](https://eslint.org/docs/rules/newline-per-chained-call)
+rule by enforcing a newline before each chained method call rather than only after the call that exceeded the maximum
+depth. Another difference is that this rule only applies to chained method calls, not to chained property accessors.
 
 ## How to use
 
@@ -54,23 +54,23 @@ foo.bar.baz.qux;
 
 ## Options
 
-This rule has no configuration options.
+These are the available options:
 
-* "ignoreChainWithDepth" (default: 2) allows chains up to a specified depth.
+### `ignoreChainWithDepth`
 
-### ignoreChainWithDepth
+Specifies the maximum depth of chained allowed, default is 2.
 
 #### ❌ Incorrect
 
 ```jsx
-/*eslint newline-per-chained-call: ["error", { "ignoreChainWithDepth": 1 }]*/
+/*eslint newline-per-chained-call: ["error", {"ignoreChainWithDepth": 1}]*/
 foo().bar().baz();
 ```
 
 #### ✅ Correct
 
 ```jsx
-/*eslint newline-per-chained-call: ["error", { "ignoreChainWithDepth": 1 }]*/
+/*eslint newline-per-chained-call: ["error", {"ignoreChainWithDepth": 1}]*/
 foo()
     .bar()
     .baz();

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -13,6 +13,12 @@ export const javascript = {
     rules: {
         '@croct/argument-spacing': 'error',
         '@croct/complex-expression-spacing': 'error',
+        'newline-per-chained-call': [
+            'error',
+            {
+                ignoreChainWithDepth: 2,
+            },
+        ],
         'array-bracket-newline': [
             'error',
             'consistent',

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -13,12 +13,8 @@ export const javascript = {
     rules: {
         '@croct/argument-spacing': 'error',
         '@croct/complex-expression-spacing': 'error',
-        'newline-per-chained-call': [
-            'error',
-            {
-                ignoreChainWithDepth: 2,
-            },
-        ],
+        '@croct/newline-per-chained-call': 'error',
+        'newline-per-chained-call': 'off',
         'array-bracket-newline': [
             'error',
             'consistent',

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -99,7 +99,11 @@ export const javascript = {
             'error',
             {
                 code: 100,
-                ignoreStrings: true,
+                ignoreStrings: false,
+                ignoreComments: false,
+                ignoreTemplateLiterals: false,
+                ignoreTrailingComments: false,
+                ignoreUrls: false,
             },
         ],
         'no-await-in-loop': 'off',
@@ -111,12 +115,6 @@ export const javascript = {
                 max: 1,
                 maxEOF: 0,
                 maxBOF: 0,
-            },
-        ],
-        'no-plusplus': [
-            'error',
-            {
-                allowForLoopAfterthoughts: true,
             },
         ],
         'no-unused-expressions': 'error',

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,9 +1,11 @@
 import {argumentSpacing} from './argument-spacing';
 import {jsxAttributeSpacing} from './jsx-attribute-spacing';
 import {complexExpressionSpacing} from './complex-expression-spacing';
+import {newlinePerChainedCall} from './newline-per-chained-call';
 
 export const rules = {
     'argument-spacing': argumentSpacing,
     'jsx-attribute-spacing': jsxAttributeSpacing,
     'complex-expression-spacing': complexExpressionSpacing,
+    'newline-per-chained-call': newlinePerChainedCall,
 };

--- a/src/rules/newline-per-chained-call/index.test.ts
+++ b/src/rules/newline-per-chained-call/index.test.ts
@@ -1,0 +1,283 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {ESLintUtils} from '@typescript-eslint/utils';
+import {newlinePerChainedCall} from './index';
+
+const ruleTester = new ESLintUtils.RuleTester({
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true,
+        },
+    },
+});
+
+ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
+    valid: [
+        {code: '_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();'},
+        {code: 'a()\n.b()\n.c\n.e'},
+        {code: 'const a = m1.m2(); let b = m1.m2();\nvar c = m1.m2()'},
+        {code: 'const a = m1()\n.m2();'},
+        {code: 'const a = m1();'},
+        {code: 'a().b().c'},
+        {code: 'const foo = a.b.c.e.d'},
+        {code: "a.b.c.e.d = 'foo'"},
+        {code: 'a().b().c()'},
+        {code: 'const a = window\n.location\n.href\n.match(/(^[^#]*)/)[0];'},
+        {code: "const a = window['location']\n.href\n.match(/(^[^#]*)/)[0];"},
+        {code: "const a = window['location'].href.match(/(^[^#]*)/)[0];"},
+        {
+            code: 'const a = m1().m2.m3().m4;',
+            options: [
+                {
+                    ignoreChainWithDepth: 4,
+                },
+            ],
+        },
+        {
+            code: 'const a = m1().m2.m3().m4.m5().m6.m7().m8.m9();',
+            options: [
+                {
+                    ignoreChainWithDepth: 8,
+                },
+            ],
+        },
+    ],
+    invalid: [
+        {
+            code: 'a.b.c.e.d()',
+            output: 'a\n.b\n.c\n.e\n.d()',
+            errors: [
+                {
+                    line: 1,
+                    column: 3,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 1,
+                    column: 5,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 1,
+                    column: 7,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 1,
+                    column: 9,
+                    messageId: 'expectedLineBreak',
+                },
+            ],
+        },
+        {
+            code: '_\n.chain({})\n.map(foo)\n.filter(bar).value();',
+            output: `_
+.chain({})
+.map(foo)
+.filter(bar)
+.value();`,
+            errors: [
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 4,
+                    column: 14,
+                },
+            ],
+        },
+        {
+            code: 'a().b().c().e.d()',
+            output: `a()
+.b()
+.c()
+.e
+.d()`,
+            errors: [
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 5,
+                },
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 9,
+                },
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 13,
+                },
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 15,
+                },
+            ],
+        },
+        {
+            code: 'a.b.c().e().d()',
+            output: `a
+.b
+.c()
+.e()
+.d()`,
+            errors: [
+                {
+                    line: 1,
+                    column: 3,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 1,
+                    column: 5,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 1,
+                    column: 9,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 1,
+                    column: 13,
+                    messageId: 'expectedLineBreak',
+                },
+            ],
+        },
+        {
+            code: '_.chain({}).map(a).value();',
+            output: `_
+.chain({})
+.map(a)
+.value();`,
+            errors: [
+                {
+                    line: 1,
+                    column: 3,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 1,
+                    column: 13,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 1,
+                    column: 20,
+                    messageId: 'expectedLineBreak',
+                },
+            ],
+        },
+        {
+            code: 'const a = m1().m2\n.m3().m4().m5().m6().m7();',
+            output: `const a = m1()
+.m2
+.m3()
+.m4()
+.m5()
+.m6()
+.m7();`,
+            options: [
+                {
+                    ignoreChainWithDepth: 3,
+                },
+            ],
+            errors: [
+                {
+                    line: 1,
+                    column: 16,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 2,
+                    column: 7,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 2,
+                    column: 12,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 2,
+                    column: 17,
+                    messageId: 'expectedLineBreak',
+                },
+                {
+                    line: 2,
+                    column: 22,
+                    messageId: 'expectedLineBreak',
+                },
+            ],
+        },
+        {
+            code: '(foo).bar().biz()',
+            output: `(foo)
+.bar()
+.biz()`,
+            options: [
+                {
+                    ignoreChainWithDepth: 1,
+                },
+            ],
+            errors: [
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 7,
+                },
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 13,
+                },
+            ],
+        },
+        {
+            code: 'foo.bar(). /* comment */ biz()',
+            output: `foo
+.bar()
+. /* comment */ biz()`,
+            options: [
+                {
+                    ignoreChainWithDepth: 1,
+                },
+            ],
+            errors: [
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 5,
+                },
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 26,
+                },
+            ],
+        },
+        {
+            code: 'foo.bar() /* comment */ .biz()',
+            output: `foo
+.bar() /* comment */ 
+.biz()`,
+            options: [
+                {
+                    ignoreChainWithDepth: 1,
+                },
+            ],
+            errors: [
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 5,
+                },
+                {
+                    messageId: 'expectedLineBreak',
+                    line: 1,
+                    column: 26,
+                },
+            ],
+        },
+    ],
+});

--- a/src/rules/newline-per-chained-call/index.test.ts
+++ b/src/rules/newline-per-chained-call/index.test.ts
@@ -71,7 +71,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: '_\n.chain({})\n.map(foo)\n.filter(bar).value();',
-            output: `_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();`,
+            output: '_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();',
             errors: [
                 {
                     messageId: 'expectedLineBreak',
@@ -82,7 +82,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'a().b().c().e.d()',
-            output: `a()\n.b()\n.c()\n.e\n.d()`,
+            output: 'a()\n.b()\n.c()\n.e\n.d()',
             errors: [
                 {
                     messageId: 'expectedLineBreak',
@@ -108,7 +108,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'a.b.c().e().d()',
-            output: `a\n.b\n.c()\n.e()\n.d()`,
+            output: 'a\n.b\n.c()\n.e()\n.d()',
             errors: [
                 {
                     line: 1,
@@ -134,7 +134,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: '_.chain({}).map(a).value();',
-            output: `_\n.chain({})\n.map(a)\n.value();`,
+            output: '_\n.chain({})\n.map(a)\n.value();',
             errors: [
                 {
                     line: 1,
@@ -155,7 +155,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'const a = m1().m2\n.m3().m4().m5().m6().m7();',
-            output: `const a = m1()\n.m2\n.m3()\n.m4()\n.m5()\n.m6()\n.m7();`,
+            output: 'const a = m1()\n.m2\n.m3()\n.m4()\n.m5()\n.m6()\n.m7();',
             options: [
                 {
                     ignoreChainWithDepth: 3,
@@ -191,7 +191,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: '(foo).bar().biz()',
-            output: `(foo)\n.bar()\n.biz()`,
+            output: '(foo)\n.bar()\n.biz()',
             options: [
                 {
                     ignoreChainWithDepth: 1,
@@ -212,7 +212,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'foo.bar(). /* comment */ biz()',
-            output: `foo\n.bar()\n. /* comment */ biz()`,
+            output: 'foo\n.bar()\n. /* comment */ biz()',
             options: [
                 {
                     ignoreChainWithDepth: 1,
@@ -233,7 +233,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'foo.bar() /* comment */ .biz()',
-            output: `foo\n.bar() /* comment */ \n.biz()`,
+            output: 'foo\n.bar() /* comment */ \n.biz()',
             options: [
                 {
                     ignoreChainWithDepth: 1,

--- a/src/rules/newline-per-chained-call/index.test.ts
+++ b/src/rules/newline-per-chained-call/index.test.ts
@@ -71,11 +71,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: '_\n.chain({})\n.map(foo)\n.filter(bar).value();',
-            output: `_
-.chain({})
-.map(foo)
-.filter(bar)
-.value();`,
+            output: `_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();`,
             errors: [
                 {
                     messageId: 'expectedLineBreak',
@@ -86,11 +82,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'a().b().c().e.d()',
-            output: `a()
-.b()
-.c()
-.e
-.d()`,
+            output: `a()\n.b()\n.c()\n.e\n.d()`,
             errors: [
                 {
                     messageId: 'expectedLineBreak',
@@ -116,11 +108,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'a.b.c().e().d()',
-            output: `a
-.b
-.c()
-.e()
-.d()`,
+            output: `a\n.b\n.c()\n.e()\n.d()`,
             errors: [
                 {
                     line: 1,
@@ -146,10 +134,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: '_.chain({}).map(a).value();',
-            output: `_
-.chain({})
-.map(a)
-.value();`,
+            output: `_\n.chain({})\n.map(a)\n.value();`,
             errors: [
                 {
                     line: 1,
@@ -170,13 +155,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'const a = m1().m2\n.m3().m4().m5().m6().m7();',
-            output: `const a = m1()
-.m2
-.m3()
-.m4()
-.m5()
-.m6()
-.m7();`,
+            output: `const a = m1()\n.m2\n.m3()\n.m4()\n.m5()\n.m6()\n.m7();`,
             options: [
                 {
                     ignoreChainWithDepth: 3,
@@ -212,9 +191,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: '(foo).bar().biz()',
-            output: `(foo)
-.bar()
-.biz()`,
+            output: `(foo)\n.bar()\n.biz()`,
             options: [
                 {
                     ignoreChainWithDepth: 1,
@@ -235,9 +212,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'foo.bar(). /* comment */ biz()',
-            output: `foo
-.bar()
-. /* comment */ biz()`,
+            output: `foo\n.bar()\n. /* comment */ biz()`,
             options: [
                 {
                     ignoreChainWithDepth: 1,
@@ -258,9 +233,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'foo.bar() /* comment */ .biz()',
-            output: `foo
-.bar() /* comment */ 
-.biz()`,
+            output: `foo\n.bar() /* comment */ \n.biz()`,
             options: [
                 {
                     ignoreChainWithDepth: 1,

--- a/src/rules/newline-per-chained-call/index.ts
+++ b/src/rules/newline-per-chained-call/index.ts
@@ -1,0 +1,155 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {TSESTree} from '@typescript-eslint/experimental-utils';
+import {createRule} from '../createRule';
+
+const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/u;
+
+export const newlinePerChainedCall = createRule({
+    name: 'newline-per-chained-call',
+    meta: {
+        type: 'layout',
+        docs: {
+            description: 'Require a newline after each call in a method chain',
+            recommended: 'error',
+        },
+        fixable: 'whitespace',
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    ignoreChainWithDepth: {
+                        type: 'integer',
+                        minimum: 1,
+                        maximum: 10,
+                        default: 2,
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        messages: {
+            expectedLineBreak: 'Expected line break before `{{propertyName}}`.',
+        },
+    },
+    defaultOptions: [
+        {
+            ignoreChainWithDepth: 2,
+        },
+    ],
+    create: context => {
+        const options = context.options[0] ?? {};
+        const ignoreChainWithDepth = options.ignoreChainWithDepth ?? 2;
+
+        const sourceCode = context.getSourceCode();
+
+        function getPropertyText(node: TSESTree.MemberExpression): string {
+            const prefix = '.';
+            const lines = sourceCode.getText(node.property)
+                .split(LINEBREAK_MATCHER);
+
+            return prefix + lines[0];
+        }
+
+        function isTokenOnSameLine(
+            left: TSESTree.LeftHandSideExpression,
+            right: TSESTree.Expression | TSESTree.PrivateIdentifier,
+        ): boolean {
+            return left.loc.end.line === right.loc.start.line;
+        }
+
+        function hasObjectAndPropertyOnSameLine(node: TSESTree.MemberExpression): boolean {
+            return (
+                isTokenOnSameLine(
+                    node.object,
+                    node.property,
+                )
+            );
+        }
+
+        function isNotClosingParenToken(token: TSESTree.Token): boolean {
+            return token.value !== ')' || token.type !== 'Punctuator';
+        }
+
+        function validateCallExpressionIgnoreDepth(
+            node: TSESTree.CallExpression | TSESTree.MemberExpression,
+        ): void {
+            let hasCallExpression = false;
+
+            if (node.type === 'CallExpression') {
+                hasCallExpression = true;
+            }
+
+            if (
+                (node.parent !== undefined)
+                && node.parent.type !== 'CallExpression'
+                && node.parent.type !== 'MemberExpression'
+            ) {
+                const memberExpressions = [];
+
+                let currentNode = (
+                    node.type === 'CallExpression'
+                        ? node.callee
+                        : node
+                );
+
+                while (
+                    currentNode.type === 'CallExpression'
+                    || currentNode.type === 'MemberExpression'
+                ) {
+                    if (currentNode.type === 'MemberExpression') {
+                        if (
+                            currentNode.property.type === 'Identifier'
+                            && !currentNode.computed
+                        ) {
+                            memberExpressions.push(currentNode);
+                        }
+
+                        currentNode = currentNode.object;
+                    } else if (currentNode.type === 'CallExpression') {
+                        currentNode = currentNode.callee;
+                    }
+                }
+
+                if (
+                    memberExpressions.length > ignoreChainWithDepth
+                    && hasCallExpression
+                    && memberExpressions.some(hasObjectAndPropertyOnSameLine)
+                ) {
+                    memberExpressions
+                        .filter(hasObjectAndPropertyOnSameLine)
+                        .forEach(memberExpression => {
+                            context.report({
+                                node: memberExpression.property,
+                                loc: memberExpression.property.loc.start,
+                                messageId: 'expectedLineBreak',
+                                data: {
+                                    propertyName: getPropertyText(memberExpression),
+                                },
+                                fix: fixer => {
+                                    const firstTokenAfterObject = sourceCode.getTokenAfter(
+                                        memberExpression.object,
+                                        isNotClosingParenToken,
+                                    );
+
+                                    return fixer.insertTextBefore(firstTokenAfterObject!, '\n');
+                                },
+                            });
+                        });
+                }
+            }
+        }
+
+        return {
+            CallExpression: (node: TSESTree.CallExpression): void => {
+                if (node.callee == null || node.callee.type !== 'MemberExpression') {
+                    return;
+                }
+
+                validateCallExpressionIgnoreDepth(node);
+            },
+            MemberExpression: (node: TSESTree.MemberExpression): void => {
+                validateCallExpressionIgnoreDepth(node);
+            },
+        };
+    },
+});

--- a/src/rules/newline-per-chained-call/index.ts
+++ b/src/rules/newline-per-chained-call/index.ts
@@ -129,11 +129,9 @@ export const newlinePerChainedCall = createRule({
 
         return {
             CallExpression: (node: TSESTree.CallExpression): void => {
-                if (node.callee == null || node.callee.type !== 'MemberExpression') {
-                    return;
+                if (node.callee?.type === 'MemberExpression') {
+                    validateCallExpressionIgnoreDepth(node);
                 }
-
-                validateCallExpressionIgnoreDepth(node);
             },
             MemberExpression: (node: TSESTree.MemberExpression): void => {
                 validateCallExpressionIgnoreDepth(node);

--- a/src/rules/newline-per-chained-call/index.ts
+++ b/src/rules/newline-per-chained-call/index.ts
@@ -50,20 +50,8 @@ export const newlinePerChainedCall = createRule({
             return prefix + lines[0];
         }
 
-        function isTokenOnSameLine(
-            left: TSESTree.LeftHandSideExpression,
-            right: TSESTree.Expression | TSESTree.PrivateIdentifier,
-        ): boolean {
-            return left.loc.end.line === right.loc.start.line;
-        }
-
         function hasObjectAndPropertyOnSameLine(node: TSESTree.MemberExpression): boolean {
-            return (
-                isTokenOnSameLine(
-                    node.object,
-                    node.property,
-                )
-            );
+            return node.object.loc.end.line === node.property.loc.start.line;
         }
 
         function isNotClosingParenToken(token: TSESTree.Token): boolean {


### PR DESCRIPTION
## Summary

Include a rule to break lines when functions (`CallExpression`) have more than one chained call.

**Why do we need a custom rule?**
The ESLint `newline-per-chained-call` is not so flexible to have some behaviors that we thought is necessary.

Examples:
* When the default value of `ignoreChainWithDepth` is surpassed only the following chained calls would break the line:

  ❌  ESLint newline-per-chained-call
  ```tsx
  // Entry code
  foo().bar().baz().quz()
  
  // Output code
  foo().bar().baz()
      .quz()
  ```

  ✅ Croct newline-per-chained-call
  ```tsx
  foo().bar().baz().quz()
  
  // Output code
  foo()
      .bar()
      .baz()
      .quz()
  ```

* When the chained calls were only `MemberExpression`:

  ❌  ESLint newline-per-chained-call
  ```tsx
  // Input code
  '&:focus-visible': {
      borderColor: ({colors}): string => colors.ui.style.shadow.ring.emphasized,
      boxShadow: ring('emphasized', false, '1px'),
  },
  
  // Output code
  '&:focus-visible': {
      borderColor: ({colors}): string => colors
          .ui
          .style
          .shadow
          .ring
          .emphasized,
      boxShadow: ring('emphasized', false, '1px'),
  },
  ```
  
  ✅ Croct newline-per-chained-call
  ```tsx
  // Input code
  '&:focus-visible': {
      borderColor: ({colors}): string => colors.ui.style.shadow.ring.emphasized,
      boxShadow: ring('emphasized', false, '1px'),
  },
  
  // Output code
  '&:focus-visible': {
      borderColor: ({colors}): string => colors.ui.style.shadow.ring.emphasized,
      boxShadow: ring('emphasized', false, '1px'),
  },
  ```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings