### PR TITLE
Fix chained-call rules

### DIFF
--- a/src/rules/min-chained-call-depth/index.test.ts
+++ b/src/rules/min-chained-call-depth/index.test.ts
@@ -19,7 +19,7 @@ ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
             code: '                    const expressionsOnSameLine = memberExpressions'
                 + '\n.filter(hasObjectAndPropertyOnSameLine);',
         },
-        {code: 'a()\n.b()\n.c();'},
+        {code: 'a().b()\n.c();'},
         {
             code: 'expect(screen.getElementById("very-long-identifier"))\n.toBe(true);',
             options: [
@@ -38,6 +38,61 @@ ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
         },
     ],
     invalid: [
+        {
+            code: 'a()\n.b()\n.c();',
+            output: 'a().b()\n.c();',
+            errors: [
+                {
+                    line: 1,
+                    column: 4,
+                    messageId: 'unexpectedLineBreak',
+                },
+            ],
+        },
+        {
+            code: 'a()\n.b\n.c();',
+            output: 'a().b\n.c();',
+            errors: [
+                {
+                    line: 1,
+                    column: 4,
+                    messageId: 'unexpectedLineBreak',
+                },
+            ],
+        },
+        {
+            code: 'a\n.b()\n.c();',
+            output: 'a.b()\n.c();',
+            errors: [
+                {
+                    line: 1,
+                    column: 2,
+                    messageId: 'unexpectedLineBreak',
+                },
+            ],
+        },
+        {
+            code: 'a()\n.b()\n.c()\n.d();',
+            output: 'a().b()\n.c()\n.d();',
+            errors: [
+                {
+                    line: 1,
+                    column: 4,
+                    messageId: 'unexpectedLineBreak',
+                },
+            ],
+        },
+        {
+            code: 'a()\n.b();',
+            output: 'a().b();',
+            errors: [
+                {
+                    line: 1,
+                    column: 4,
+                    messageId: 'unexpectedLineBreak',
+                },
+            ],
+        },
         {
             code: 'expect(screen.getElementById("very-long-identifier"))\n.toBe(true)',
             output: 'expect(screen.getElementById("very-long-identifier")).toBe(true)',

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -74,7 +74,7 @@ export const minChainedCallDepth = createRule({
 
             // If the node is a call expression we need to validate it's callee as a member
             // expression.
-            // If the node itself already is a member expression, like the
+            // If the node itself is already a member expression, like the
             // `property` in `this.property.function()`, we validate the node directly.
             const callee = node.type === 'CallExpression' ? node.callee : node;
 

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -47,33 +47,57 @@ export const minChainedCallDepth = createRule({
             ) {
                 if (currentNode.type === 'MemberExpression') {
                     currentNode = currentNode.object;
+
+                    depth += 1;
                 } else if (currentNode.type === 'CallExpression') {
                     currentNode = currentNode.callee;
                 }
-
-                depth += 1;
             }
 
             return depth;
         }
 
-        function check(node: TSESTree.CallExpression): void {
+        function check(node: TSESTree.CallExpression | TSESTree.MemberExpression): void {
+            // If the node is a member expression inside a call expression skip, this is to ensure
+            // that we consider the correct line length of the result.
+            //
+            // Example:
+            //     ```ts
+            //     foo
+            //        .bar();
+            //     ```
+            //     The replacement of this input should be `foo.bar();`, which has 10 character.
+            //     Without this check it would consider the length up to `r`, which is 7.
+            if (node.type === 'MemberExpression' && node.parent?.type === 'CallExpression') {
+                return;
+            }
+
+            // If the node is a call expression we need to validate it's callee as a member
+            // expression.
+            // If the node itself already is a member expression, like the
+            // `property` in `this.property.function()`, we validate the node directly.
+            const callee = node.type === 'CallExpression' ? node.callee : node;
+
             if (
-                node.parent?.type === 'MemberExpression'
-                || node.parent?.type === 'CallExpression'
-                || node.callee.type !== 'MemberExpression'
-                || node.callee.computed
-                || node.callee.object.loc.end.line === node.callee.property.loc.start.line
+                // If the callee is not a member expression, we can skip.
+                // For example, root level calls like `foo();`.
+                callee.type !== 'MemberExpression'
+                // If the callee is a computed member expression, like `foo[bar]()`, we can skip.
+                || callee.computed
+                // If the callee is already in the same line as it's object, we can skip.
+                || callee.object.loc.end.line === callee.property.loc.start.line
             ) {
                 return;
             }
 
-            if (getDepth(node) > 3) {
+            // We only inline the first level of chained calls.
+            // If the current call is nested inside another call, we can skip.
+            if (getDepth(callee) > 1) {
                 return;
             }
 
             const {maxLineLength = 100} = context.options[0] ?? {};
-            const {property} = node.callee;
+            const {property} = callee;
             const lastToken = sourceCode.getLastToken(node, {
                 filter: token => token.loc.end.line === property.loc.start.line,
             })!;
@@ -86,7 +110,7 @@ export const minChainedCallDepth = createRule({
                 ),
             });
 
-            const lineLength = node.callee.object.loc.end.column
+            const lineLength = callee.object.loc.end.column
                 + lastToken.loc.end.column - property.loc.start.column
                 + 1
                 + (semicolon !== null ? 1 : 0);
@@ -95,7 +119,7 @@ export const minChainedCallDepth = createRule({
                 return;
             }
 
-            const punctuator = sourceCode.getTokenBefore(node.callee.property)!;
+            const punctuator = sourceCode.getTokenBefore(callee.property)!;
 
             const previousToken = sourceCode.getTokenBefore(punctuator, {includeComments: true})!;
             const nextToken = sourceCode.getTokenAfter(punctuator, {includeComments: true})!;
@@ -107,8 +131,8 @@ export const minChainedCallDepth = createRule({
             context.report({
                 node: node,
                 loc: {
-                    start: node.callee.object.loc.end,
-                    end: node.callee.property.loc.start,
+                    start: callee.object.loc.end,
+                    end: callee.property.loc.start,
                 },
                 messageId: 'unexpectedLineBreak',
                 fix: fixer => fixer.replaceTextRange(
@@ -120,6 +144,9 @@ export const minChainedCallDepth = createRule({
 
         return {
             CallExpression: (node: TSESTree.CallExpression): void => {
+                check(node);
+            },
+            MemberExpression: (node: TSESTree.MemberExpression): void => {
                 check(node);
             },
         };

--- a/src/rules/newline-per-chained-call/index.test.ts
+++ b/src/rules/newline-per-chained-call/index.test.ts
@@ -22,7 +22,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         {code: 'const foo = a.b.c.e.d'},
         {code: 'this.a().b'},
         {code: 'this.a()\n.b\n.c'},
-        {code: 'this\n.a\n.b\n.c.d'},
+        {code: 'this.a\n.b\n.c.d'},
         {code: 'a.b()\n.b\n.c'},
         {code: "a.b.c.e.d = 'foo'"},
         {code: 'a().b().c()'},
@@ -48,14 +48,20 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
     ],
     invalid: [
         {
-            code: 'this.a.b.c.d()',
-            output: 'this\n.a\n.b\n.c\n.d()',
+            code: 'this\n.a\n.b\n.c\n.d()',
+            output: 'this.a\n.b\n.c\n.d()',
             errors: [
                 {
                     line: 1,
                     column: 6,
                     messageId: 'expectedLineBreak',
                 },
+            ],
+        },
+        {
+            code: 'this.a.b.c.d()',
+            output: 'this.a\n.b\n.c\n.d()',
+            errors: [
                 {
                     line: 1,
                     column: 8,
@@ -91,13 +97,8 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'a.b.c.e.d()',
-            output: 'a\n.b\n.c\n.e\n.d()',
+            output: 'a.b\n.c\n.e\n.d()',
             errors: [
-                {
-                    line: 1,
-                    column: 3,
-                    messageId: 'expectedLineBreak',
-                },
                 {
                     line: 1,
                     column: 5,
@@ -154,13 +155,8 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
         },
         {
             code: 'a.b.c().e().d()',
-            output: 'a\n.b\n.c()\n.e()\n.d()',
+            output: 'a.b\n.c()\n.e()\n.d()',
             errors: [
-                {
-                    line: 1,
-                    column: 3,
-                    messageId: 'expectedLineBreak',
-                },
                 {
                     line: 1,
                     column: 5,

--- a/src/rules/newline-per-chained-call/index.test.ts
+++ b/src/rules/newline-per-chained-call/index.test.ts
@@ -48,17 +48,6 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
     ],
     invalid: [
         {
-            code: 'this\n.a\n.b\n.c\n.d()',
-            output: 'this.a\n.b\n.c\n.d()',
-            errors: [
-                {
-                    line: 1,
-                    column: 6,
-                    messageId: 'expectedLineBreak',
-                },
-            ],
-        },
-        {
             code: 'this.a.b.c.d()',
             output: 'this.a\n.b\n.c\n.d()',
             errors: [

--- a/src/rules/newline-per-chained-call/index.ts
+++ b/src/rules/newline-per-chained-call/index.ts
@@ -29,6 +29,7 @@ export const newlinePerChainedCall = createRule({
         ],
         messages: {
             expectedLineBreak: 'Expected line break before `{{propertyName}}`.',
+            unexpectedLineBreak: 'Unexpected line break after `{{propertyName}}`.',
         },
     },
     defaultOptions: [
@@ -44,8 +45,7 @@ export const newlinePerChainedCall = createRule({
 
         function getPropertyText(node: TSESTree.MemberExpression): string {
             const prefix = '.';
-            const lines = sourceCode.getText(node.property)
-                .split(LINEBREAK_MATCHER);
+            const lines = sourceCode.getText(node.property).split(LINEBREAK_MATCHER);
 
             return prefix + lines[0];
         }
@@ -109,7 +109,8 @@ export const newlinePerChainedCall = createRule({
 
                     if (
                         rootNode.type === 'MemberExpression'
-                        && rootNode.parent?.type === 'CallExpression'
+                        && (rootNode.parent?.type === 'CallExpression'
+                            || rootNode.parent?.type === 'MemberExpression')
                         && (rootNode.object.type === 'ThisExpression'
                             || rootNode.object.type === 'Identifier')
                     ) {

--- a/src/rules/newline-per-chained-call/index.ts
+++ b/src/rules/newline-per-chained-call/index.ts
@@ -29,7 +29,6 @@ export const newlinePerChainedCall = createRule({
         ],
         messages: {
             expectedLineBreak: 'Expected line break before `{{propertyName}}`.',
-            unexpectedLineBreak: 'Unexpected line break after `{{propertyName}}`.',
         },
     },
     defaultOptions: [


### PR DESCRIPTION
## Summary

- Fix newline-chained-call to consider MemberExpressions on the exclusion of the first chained call.
- Fix min-chained-call-depth logic to also use MemberExpression as a root node.

More details of the changes were added to the comments in the code.

Co-authored by: @Fryuni 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings