### PR TITLE
Disallow useless escape characters

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -202,6 +202,7 @@ export const javascript = {
                 ],
             },
         ],
+        'no-useless-escape': 'error',
     },
     overrides: [
         {


### PR DESCRIPTION
## Summary
Enables the [no-useless-escape](https://eslint.org/docs/rules/no-useless-escape) linter.
