### PR TITLE
Allow typescript namespaces

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -74,6 +74,10 @@ export const typescript = {
                     },
                 }],
                 'no-undef': 'off',
+                '@typescript-eslint/no-namespace': 'off',
+                '@typescript-eslint/no-redeclare': ['error', {
+                    ignoreDeclarationMerge: true,
+                }],
             },
         },
         {


### PR DESCRIPTION
## Summary
Allow the use of namespaces and same module declaration merging.
The use of namespaces with declaration merging is documented [here](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-namespaces-with-classes-functions-and-enums).
Example use cases on our codebase have been discussed in [this thread](https://github.com/croct-tech/admin-backend/pull/376#discussion_r825073543).

This change enables patterns such as:
<details>
<summary>Inner classes</summary>

```ts
export class Collection {
    public getEntry(position: number): Collection.Entry {}
}

export namespace Collection {
    export class Entry {}
}
```
</details>
<details>
<summary>Associated methods on types</summary>

```ts
import {Instant} from '@croct-tech/time';

export type Foo {
    someTime: Instant
}

export namespace Foo {
    type JsonFoo = {
        someTime: number,
    };

    export function toJSON(foo: Foo): JsonFoo {
        return {
            someTime: foo.someTime.toMillis(),
        };
    }

    export function fromJSON(json: JsonFoo): Foo {
        return {
            someTime: Instant.fromEpochMillis(json.someTime),
        };
    }
}

// Using

const jsonString = '{"someTime": 123}';

const jsonFoo = JSON.parse(jsonString);

const foo = Foo.fromJSON(jsonFoo);
```
</details>
<details>
<summary>Properly typed inheritable class methods (advanced use case)</summary>

This only allows instantiating the base class.
```ts
export class Foo {
    public static fromString(value: string): Base {
        return new Base(value);
    }
}

export class Bar extends Foo {}

const value = Bar.fromString("bar");

console.assert(!(value instanceof Bar)); // It is not an instance of Bar
```

This allows instantiating the subclasses, but the type for TS will be the base class.
```ts
export class Foo {
    public static fromString(value: string): Base {
        return new this(value);
    }
}

export class Bar extends Foo {}

// value has type Foo for typescript
const value = Bar.fromString("bar");

console.assert(value instanceof Bar); // Even though it is an instance of Bar
```

This allows the static method constructor to be used on subclasses
```ts
export class Foo {
   public constructor(value: string) {}
}

export namespace Foo {
    type FooConstructor<T extends Foo> = { new(value: string): T };

    export function fromString<T>(this: FooConstructor<T>, value: string): T {
        return new this(value);
    }

    export function fromInteger<T>(this: FooConstructor<T>, value: number): T {
        return new this(value.toFixed(0));
    }
}

export class Bar extends Foo {}

const value = Bar.fromString("bar");
console.assert(value instanceof Bar);

const valueTwo = Bar.fromInteger(123);
console.assert(value instanceof Bar);

// Subclass can overwrite the constructor
export class Baz extends Foo {
   public constructor(value: string, options?: Options) {}
}

// Still works
Baz.fromString("baz");

// Subclass might overwrite the constructor and make it incompatible
export class Quox extends Foo {
   public constructor(value: string, options: Options) {}
}

// New class is still usable
new Quox("something", {});

/// But not the static methods, this breaks at compile time
// Quox.fromString("quox");
```
</details>

And others