### PR TITLE
Add eslint-comments plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint-config-airbnb": "^19.0",
         "eslint-config-airbnb-base": "^15.0",
         "eslint-plugin-cypress": "^2.12",
+        "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.25",
         "eslint-plugin-import-newlines": "^1.1",
         "eslint-plugin-jest": "^26.1",
@@ -2580,6 +2581,32 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/eslint-plugin-eslint-plugin": {
@@ -8191,6 +8218,22 @@
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        }
+      }
+    },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-config-airbnb": "^19.0",
     "eslint-config-airbnb-base": "^15.0",
     "eslint-plugin-cypress": "^2.12",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.25",
     "eslint-plugin-import-newlines": "^1.1",
     "eslint-plugin-jest": "^26.1",

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -2,6 +2,7 @@ export const javascript = {
     extends: [
         'plugin:jest/recommended',
         'airbnb-base',
+        'plugin:eslint-comments/recommended',
     ],
     plugins: [
         'jest',
@@ -15,6 +16,13 @@ export const javascript = {
         '@croct/complex-expression-spacing': 'error',
         '@croct/newline-per-chained-call': 'error',
         '@croct/min-chained-call-depth': 'error',
+        'eslint-comments/disable-enable-pair': [
+            'error',
+            {
+                allowWholeFile: true,
+            },
+        ],
+        'eslint-comments/require-description': 'error',
         'newline-per-chained-call': 'off',
         'no-plusplus': 'off',
         'array-bracket-newline': [

--- a/src/rules/argument-spacing/index.test.ts
+++ b/src/rules/argument-spacing/index.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {ESLintUtils} from '@typescript-eslint/utils';
 import {argumentSpacing} from './index';
 

--- a/src/rules/argument-spacing/index.ts
+++ b/src/rules/argument-spacing/index.ts
@@ -1,5 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-// eslint-disable-next-line import/no-extraneous-dependencies
+/*
+    eslint-disable @typescript-eslint/no-non-null-assertion
+    --
+    Disable the rule to reduce the number of branches
+*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {createRule} from '../createRule';
 

--- a/src/rules/complex-expression-spacing/index.test.ts
+++ b/src/rules/complex-expression-spacing/index.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {ESLintUtils} from '@typescript-eslint/utils';
 import {complexExpressionSpacing} from './index';
 

--- a/src/rules/complex-expression-spacing/index.ts
+++ b/src/rules/complex-expression-spacing/index.ts
@@ -1,4 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/*
+    eslint-disable @typescript-eslint/no-non-null-assertion
+    --
+    Disable the rule to reduce the number of branches
+*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {createRule} from '../createRule';
 

--- a/src/rules/jsx-attribute-spacing/index.test.ts
+++ b/src/rules/jsx-attribute-spacing/index.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {ESLintUtils} from '@typescript-eslint/utils';
 import {jsxAttributeSpacing} from './index';
 

--- a/src/rules/jsx-attribute-spacing/index.ts
+++ b/src/rules/jsx-attribute-spacing/index.ts
@@ -1,4 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/*
+    eslint-disable @typescript-eslint/no-non-null-assertion
+    --
+    Disable the rule to reduce the number of branches
+*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {createRule} from '../createRule';
 

--- a/src/rules/min-chained-call-depth/index.test.ts
+++ b/src/rules/min-chained-call-depth/index.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {ESLintUtils} from '@typescript-eslint/utils';
 import {minChainedCallDepth} from './index';
 

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -1,4 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/*
+    eslint-disable @typescript-eslint/no-non-null-assertion
+    --
+    Disable the rule to reduce the number of branches
+*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {isCommentToken} from '@typescript-eslint/utils/dist/ast-utils';
 import {createRule} from '../createRule';

--- a/src/rules/newline-per-chained-call/index.test.ts
+++ b/src/rules/newline-per-chained-call/index.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {ESLintUtils} from '@typescript-eslint/utils';
 import {newlinePerChainedCall} from './index';
 

--- a/src/rules/newline-per-chained-call/index.ts
+++ b/src/rules/newline-per-chained-call/index.ts
@@ -1,4 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/*
+    eslint-disable @typescript-eslint/no-non-null-assertion
+    --
+    Disable the rule to reduce the number of branches
+*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {createRule} from '../createRule';
 


### PR DESCRIPTION
## Summary

Add a set of rules regarding ESLint comments including:

| Rule ID | Description |    |
|:--------|:------------|:---|
| [eslint-comments/<wbr>disable-enable-pair](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/disable-enable-pair.html) | require a `eslint-enable` comment for every `eslint-disable` comment | ✅  |
| [eslint-comments/<wbr>no-aggregating-enable](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-aggregating-enable.html) | disallow a `eslint-enable` comment for multiple `eslint-disable` comments | ✅  |
| [eslint-comments/<wbr>no-duplicate-disable](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-duplicate-disable.html) | disallow duplicate `eslint-disable` comments | ✅  |
| [eslint-comments/<wbr>no-unlimited-disable](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unlimited-disable.html) | disallow `eslint-disable` comments without rule names | ✅  |
| [eslint-comments/<wbr>no-unused-disable](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html) | disallow unused `eslint-disable` comments |  |
| [eslint-comments/<wbr>no-unused-enable](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unused-enable.html) | disallow unused `eslint-enable` comments | ✅  |
| [eslint-comments/<wbr>require-description](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/require-description.html) | require include descriptions in ESLint directive-comments |  |

- ✅: the rule which is enabled by `eslint-comments/recommended` preset.

For more details [check their official docs](https://mysticatea.github.io/eslint-plugin-eslint-comments/)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings