### PR TITLE
Add rule for proper multiline destructuring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-plugin-jest": "^26.1",
         "eslint-plugin-jest-dom": "^4.0",
         "eslint-plugin-jsx-a11y": "^6.5",
+        "eslint-plugin-newline-destructuring": "^1.0.1",
         "eslint-plugin-no-smart-quotes": "^1.3",
         "eslint-plugin-react": "^7.28",
         "eslint-plugin-react-hooks": "^4.3",
@@ -2765,6 +2766,14 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/eslint-plugin-newline-destructuring": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-newline-destructuring/-/eslint-plugin-newline-destructuring-1.0.1.tgz",
+      "integrity": "sha512-NOSS4Yel10oVhyFmM12AXw+koNhblZT1aj1KZkK/dAo0cA3XArbSc7JKQOvgAVvyVBaNNFTHswk49iHq/RrHTQ==",
+      "peerDependencies": {
+        "eslint": ">=7.2.0"
       }
     },
     "node_modules/eslint-plugin-no-smart-quotes": {
@@ -8343,6 +8352,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-newline-destructuring": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-newline-destructuring/-/eslint-plugin-newline-destructuring-1.0.1.tgz",
+      "integrity": "sha512-NOSS4Yel10oVhyFmM12AXw+koNhblZT1aj1KZkK/dAo0cA3XArbSc7JKQOvgAVvyVBaNNFTHswk49iHq/RrHTQ==",
+      "requires": {}
     },
     "eslint-plugin-no-smart-quotes": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-jest": "^26.1",
     "eslint-plugin-jest-dom": "^4.0",
     "eslint-plugin-jsx-a11y": "^6.5",
+    "eslint-plugin-newline-destructuring": "^1.0.1",
     "eslint-plugin-no-smart-quotes": "^1.3",
     "eslint-plugin-react": "^7.28",
     "eslint-plugin-react-hooks": "^4.3",

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -9,6 +9,7 @@ export const javascript = {
         'import',
         'no-smart-quotes',
         'import-newlines',
+        'newline-destructuring',
         '@croct',
     ],
     rules: {
@@ -211,6 +212,9 @@ export const javascript = {
             },
         ],
         'no-useless-escape': 'error',
+        'newline-destructuring/newline': ['error', {
+            maxLength: 100,
+        }],
     },
     overrides: [
         {


### PR DESCRIPTION
## Summary
Install and enables `newline-destructuring` rule from @urielvan.

```ts
// This is now auto-formatted
const {foo, bar, baz} = parameters;

// to this
const {
    foo,
    bar,
    baz,
} = parameters;
```

The line breaks are added when one of these matches:
- There is a nested multiline destructuring
- There are 3 or more restructured values (including the `...rest` value, if present)
- The entire line would be longer than 100 characters if all the restructuring was done inline

Also, if _none_ of the above matches, this rule _removes_ the line breaks and turns the whole statement into a single line.

```ts
// Turns this
const {
    foo,
    bar,
} = parameters;

// into this
const {foo, bar} = parameters;
```

Rule found and proposed by @georgekaran