### PR TITLE
Add jsx-quotes rule to React config

### DIFF
--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -20,13 +20,16 @@ export const react = {
         '@croct/jsx-attribute-spacing': 'error',
         'react/jsx-wrap-multilines': 'error',
         'react/display-name': 'off',
+        'jsx-quotes': [
+            'error',
+            'prefer-double',
+        ],
         'react/jsx-newline': [
             'error',
             {
                 prevent: true,
             },
         ],
-
         'react/jsx-no-bind': [
             'error',
             {


### PR DESCRIPTION
## Summary

Configure React config to prefer double-quotes.

✅ Valid
```tsx
<div id="id" />
```

❌  Invalid:
```tsx
<div id='id' />
```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings