### PR TITLE
Disable import/export rule for Typescript

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -10,6 +10,7 @@ export const typescript = {
             extends: ['plugin:@typescript-eslint/recommended'],
             parser: '@typescript-eslint/parser',
             rules: {
+                'import/export': 'off',
                 '@typescript-eslint/array-type': ['error', {
                     default: 'array-simple',
                 }],


### PR DESCRIPTION
## Summary

In Typescript this rule is useless since is not possible to redeclare an exported variable. Another point is that sometimes this rule would point to some false positives.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings