### PR TITLE
Increase newline-destructuring/newline items values

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -213,9 +213,14 @@ export const javascript = {
             },
         ],
         'no-useless-escape': 'error',
-        'newline-destructuring/newline': ['error', {
-            maxLength: 100,
-        }],
+        'newline-destructuring/newline': [
+            'error',
+            {
+                maxLength: 100,
+                itemsWithRest: Infinity,
+                items: Infinity,
+            },
+        ],
     },
     overrides: [
         {


### PR DESCRIPTION
## Summary

Increase items values to `Infinity`, so that it will only break to new lines when the destructuring code source is greater than `100`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings