### PR TITLE
Move eslint-plugin-sort-keys-fix to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-no-smart-quotes": "^1.3",
         "eslint-plugin-react": "^7.28",
         "eslint-plugin-react-hooks": "^4.3",
+        "eslint-plugin-sort-keys-fix": "^1.1.2",
         "eslint-plugin-testing-library": "^5.0"
       },
       "devDependencies": {
@@ -36,7 +37,6 @@
         "eslint": "^8.8",
         "eslint-plugin-eslint-plugin": "^4.1.0",
         "eslint-plugin-self": "^1.2.1",
-        "eslint-plugin-sort-keys-fix": "^1.1.2",
         "jest": "^27.5",
         "ts-jest": "^27.1",
         "typescript": "^4.5"
@@ -2887,7 +2887,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.2.tgz",
       "integrity": "sha512-DNPHFGCA0/hZIsfODbeLZqaGY/+q3vgtshF85r+YWDNCQ2apd9PNs/zL6ttKm0nD1IFwvxyg3YOTI7FHl4unrw==",
-      "dev": true,
       "dependencies": {
         "espree": "^6.1.2",
         "esutils": "^2.0.2",
@@ -2902,7 +2901,6 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2914,7 +2912,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2923,7 +2920,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
       "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-      "dev": true,
       "dependencies": {
         "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
@@ -8441,7 +8437,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.2.tgz",
       "integrity": "sha512-DNPHFGCA0/hZIsfODbeLZqaGY/+q3vgtshF85r+YWDNCQ2apd9PNs/zL6ttKm0nD1IFwvxyg3YOTI7FHl4unrw==",
-      "dev": true,
       "requires": {
         "espree": "^6.1.2",
         "esutils": "^2.0.2",
@@ -8452,20 +8447,17 @@
         "acorn": {
           "version": "7.4.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "dev": true
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
         },
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
         },
         "espree": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
           "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-          "dev": true,
           "requires": {
             "acorn": "^7.1.1",
             "acorn-jsx": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-no-smart-quotes": "^1.3",
     "eslint-plugin-react": "^7.28",
     "eslint-plugin-react-hooks": "^4.3",
+    "eslint-plugin-sort-keys-fix": "^1.1.2",
     "eslint-plugin-testing-library": "^5.0"
   },
   "devDependencies": {
@@ -63,7 +64,6 @@
     "eslint": "^8.8",
     "eslint-plugin-eslint-plugin": "^4.1.0",
     "eslint-plugin-self": "^1.2.1",
-    "eslint-plugin-sort-keys-fix": "^1.1.2",
     "jest": "^27.5",
     "ts-jest": "^27.1",
     "typescript": "^4.5"


### PR DESCRIPTION
## Summary

The `eslint-plugin-sort-keys-fix` is listed as a dev dependency, which is incorrect since the `eslint-patch` only do resolutions for non-dev dependencies.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings