### PR TITLE
Fix min-chained-call-depth rule

### DIFF
--- a/src/rules/min-chained-call-depth/index.test.ts
+++ b/src/rules/min-chained-call-depth/index.test.ts
@@ -12,6 +12,20 @@ const ruleTester = new ESLintUtils.RuleTester({
 
 ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
     valid: [
+        {
+            code: 'new StringSchema<ApiKeyPermission>().required()'
+                + '\n.strict()'
+                + '\n.oneOf(Object.values(ApiKeyPermission));',
+        },
+        {
+            code: 'new yup.StringSchema<ApiKeyPermission>().required()'
+                + '\n.strict()'
+                + '\n.oneOf(Object.values(ApiKeyPermission));',
+        },
+        {
+            code: 'await expect(analyzer.isAssignableTo("true", "boolean", true)).rejects'
+                + '\n.toThrow(new AnalysisError("Unexpected expression: true"));',
+        },
         {code: 'expect(screen.getElementById("very-long-identifier"))\n// comment\n.toBe(true);'},
         {code: 'expect(screen.getElementById("very-long-identifier")).toBe(true);'},
         {

--- a/src/rules/min-chained-call-depth/index.test.ts
+++ b/src/rules/min-chained-call-depth/index.test.ts
@@ -13,12 +13,14 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
     valid: [
         {
-            code: 'new StringSchema<ApiKeyPermission>().required()'
+            code: 'new StringSchema<ApiKeyPermission>()'
+                + '\n.required()'
                 + '\n.strict()'
                 + '\n.oneOf(Object.values(ApiKeyPermission));',
         },
         {
-            code: 'new yup.StringSchema<ApiKeyPermission>().required()'
+            code: 'new yup.StringSchema<ApiKeyPermission>()'
+                + '\n.required()'
                 + '\n.strict()'
                 + '\n.oneOf(Object.values(ApiKeyPermission));',
         },


### PR DESCRIPTION
## Summary

Include `NewExpression` when calculating the minimum chained calls depth.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings