### PR TITLE
Fix min-chained-call-depth rule

### DIFF
--- a/docs/rules/min-chained-call-depth.md
+++ b/docs/rules/min-chained-call-depth.md
@@ -89,7 +89,7 @@ Array(10)
 #### ✅ Correct
 
 ```jsx
-/*eslint min-chained-call-depth: ["error", {"ignoreChainDeeperThan": 1}]*/
+/* eslint min-chained-call-depth: ["error", {"ignoreChainDeeperThan": 1}] */
 Array(10)
     .fill(0)
     .map(foo => foo);

--- a/docs/rules/min-chained-call-depth.md
+++ b/docs/rules/min-chained-call-depth.md
@@ -74,6 +74,27 @@ expect(screen.getElementById("very-long-identifier"))
     .toBe(true);
 ```
 
+### `ignoreChainDeeperThan`
+
+Chains that are deeper than the specified number are allowed to break line, default is 2.
+
+#### ❌ Incorrect
+
+```jsx
+Array(10)
+    .fill(0)
+    .map(foo => foo);
+```
+
+#### ✅ Correct
+
+```jsx
+/*eslint min-chained-call-depth: ["error", {"ignoreChainDeeperThan": 1}]*/
+Array(10)
+    .fill(0)
+    .map(foo => foo);
+```
+
 ## Attributes
 
 - [ ] ✅ Recommended

--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -67,7 +67,7 @@ foo.bar.baz.qux;
 
 These are the available options:
 
-### `ignoreChainWithDepth`
+### `ignoreChainDeeperThan`
 
 Specifies the maximum depth of chained allowed, default is 2.
 

--- a/src/rules/min-chained-call-depth/index.test.ts
+++ b/src/rules/min-chained-call-depth/index.test.ts
@@ -19,7 +19,7 @@ ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
             code: 'Array(10).fill(0)\n.map(foo => foo)\n.slice(1);',
             options: [
                 {
-                    ignoreChainWithDepth: 3,
+                    ignoreChainDeeperThan: 2,
                 },
             ],
         },
@@ -72,7 +72,7 @@ ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
             output: 'Array(10).fill(0)\n.map(foo => foo);',
             options: [
                 {
-                    ignoreChainWithDepth: 3,
+                    ignoreChainDeeperThan: 3,
                 },
             ],
             errors: [

--- a/src/rules/min-chained-call-depth/index.test.ts
+++ b/src/rules/min-chained-call-depth/index.test.ts
@@ -12,6 +12,22 @@ const ruleTester = new ESLintUtils.RuleTester({
 
 ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
     valid: [
+        {
+            code: 'new StringSchema<ApiKeyPermission>()'
+                + '\n.required()'
+                + '\n.strict()'
+                + '\n.oneOf(Object.values(ApiKeyPermission));',
+        },
+        {
+            code: 'new yup.StringSchema<ApiKeyPermission>()'
+                + '\n.required()'
+                + '\n.strict()'
+                + '\n.oneOf(Object.values(ApiKeyPermission));',
+        },
+        {
+            code: 'await expect(analyzer.isAssignableTo("true", "boolean", true)).rejects'
+                + '\n.toThrow(new AnalysisError("Unexpected expression: true"));',
+        },
         {code: 'expect(screen.getElementById("very-long-identifier"))\n// comment\n.toBe(true);'},
         {code: 'expect(screen.getElementById("very-long-identifier")).toBe(true);'},
         {

--- a/src/rules/min-chained-call-depth/index.test.ts
+++ b/src/rules/min-chained-call-depth/index.test.ts
@@ -13,6 +13,12 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
     valid: [
         {
+            code: 'Array(10)\n.fill(0)\n.map(foo => foo)\n.slice(1);',
+        },
+        {
+            code: 'Array(10).foo\n.fill(0)\n.map(foo => foo)\n.slice(1);',
+        },
+        {
             code: 'new StringSchema<ApiKeyPermission>()'
                 + '\n.required()'
                 + '\n.strict()'
@@ -54,6 +60,17 @@ ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
     ],
     invalid: [
         {
+            code: 'Array(10)\n.fill(10);',
+            output: 'Array(10).fill(10);',
+            errors: [
+                {
+                    line: 1,
+                    column: 10,
+                    messageId: 'unexpectedLineBreak',
+                },
+            ],
+        },
+        {
             code: 'a()\n.b()\n.c();',
             output: 'a().b()\n.c();',
             errors: [
@@ -82,17 +99,6 @@ ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
                 {
                     line: 1,
                     column: 2,
-                    messageId: 'unexpectedLineBreak',
-                },
-            ],
-        },
-        {
-            code: 'a()\n.b()\n.c()\n.d();',
-            output: 'a().b()\n.c()\n.d();',
-            errors: [
-                {
-                    line: 1,
-                    column: 4,
                     messageId: 'unexpectedLineBreak',
                 },
             ],

--- a/src/rules/min-chained-call-depth/index.test.ts
+++ b/src/rules/min-chained-call-depth/index.test.ts
@@ -16,7 +16,15 @@ ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
             code: 'Array(10)\n.fill(0)\n.map(foo => foo)\n.slice(1);',
         },
         {
-            code: 'Array(10).foo\n.fill(0)\n.map(foo => foo)\n.slice(1);',
+            code: 'Array(10).fill(0)\n.map(foo => foo)\n.slice(1);',
+            options: [
+                {
+                    ignoreChainWithDepth: 3,
+                },
+            ],
+        },
+        {
+            code: 'Array(10)\n.foo\n.fill(0)\n.map(foo => foo)\n.slice(1);',
         },
         {
             code: 'new StringSchema<ApiKeyPermission>()'
@@ -59,6 +67,22 @@ ruleTester.run('min-chained-call-depth', minChainedCallDepth, {
         },
     ],
     invalid: [
+        {
+            code: 'Array(10)\n.fill(0)\n.map(foo => foo);',
+            output: 'Array(10).fill(0)\n.map(foo => foo);',
+            options: [
+                {
+                    ignoreChainWithDepth: 3,
+                },
+            ],
+            errors: [
+                {
+                    line: 1,
+                    column: 10,
+                    messageId: 'unexpectedLineBreak',
+                },
+            ],
+        },
         {
             code: 'Array(10)\n.fill(10);',
             output: 'Array(10).fill(10);',

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -98,17 +98,17 @@ export const minChainedCallDepth = createRule({
                 : node;
 
             if (
-                // If the callee is not a member expression, we can skip.
+                // If the callee is not a member expression, skip.
                 // For example, root level calls like `foo();`.
                 callee.type !== AST_NODE_TYPES.MemberExpression
-                // If the callee is a computed member expression, like `foo[bar]()`, we can skip.
+                // If the callee is a computed member expression, like `foo[bar]()`, skip.
                 || callee.computed
                 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment --
                 * NewExpression is a possible callee object type
                 */
                 // @ts-ignore
                 || callee.object.type === AST_NODE_TYPES.NewExpression
-                // If the callee is already in the same line as it's object, we can skip.
+                // If the callee is already in the same line as it's object, skip.
                 || callee.object.loc.end.line === callee.property.loc.start.line
             ) {
                 return;
@@ -118,15 +118,15 @@ export const minChainedCallDepth = createRule({
 
             maxDepth = Math.max(maxDepth, currentDepth);
 
-            // We only inline the first level of chained calls.
-            // If the current call is nested inside another call, we can skip.
+            // Only affect the root level as the total depth is must be known.
+            // If the current call is nested inside another call, skip.
             if (currentDepth > 1) {
                 return;
             }
 
             const {maxLineLength = 100, ignoreChainDeeperThan = 2} = context.options[0] ?? {};
 
-            // If the max depth is greater than ignoreChainDeeperThan, we can skip.
+            // If the max depth is greater than ignore threshold, skip
             //
             // Example:
             //     ```ts

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -104,8 +104,8 @@ export const minChainedCallDepth = createRule({
                 // If the callee is a computed member expression, like `foo[bar]()`, skip.
                 || callee.computed
                 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment --
-                * NewExpression is a possible callee object type
-                */
+                 * NewExpression is a possible callee object type
+                 */
                 // @ts-ignore
                 || callee.object.type === AST_NODE_TYPES.NewExpression
                 // If the callee is already in the same line as it's object, skip.

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -3,7 +3,7 @@
     --
     Disable the rule to reduce the number of branches
 */
-import {TSESTree} from '@typescript-eslint/experimental-utils';
+import {AST_TOKEN_TYPES, AST_NODE_TYPES, TSESTree} from '@typescript-eslint/experimental-utils';
 import {isCommentToken} from '@typescript-eslint/utils/dist/ast-utils';
 import {createRule} from '../createRule';
 
@@ -46,14 +46,14 @@ export const minChainedCallDepth = createRule({
             let currentNode: TSESTree.Node = node;
 
             while (
-                currentNode.type === 'CallExpression'
-                || currentNode.type === 'MemberExpression'
+                currentNode.type === AST_NODE_TYPES.CallExpression
+                || currentNode.type === AST_NODE_TYPES.MemberExpression
             ) {
-                if (currentNode.type === 'MemberExpression') {
+                if (currentNode.type === AST_NODE_TYPES.MemberExpression) {
                     currentNode = currentNode.object;
 
                     depth += 1;
-                } else if (currentNode.type === 'CallExpression') {
+                } else if (currentNode.type === AST_NODE_TYPES.CallExpression) {
                     currentNode = currentNode.callee;
                 }
             }
@@ -62,8 +62,8 @@ export const minChainedCallDepth = createRule({
         }
 
         function check(node: TSESTree.CallExpression | TSESTree.MemberExpression): void {
-            // If the node is a member expression inside a call expression skip, this is to ensure
-            // that we consider the correct line length of the result.
+            // If the node is a member expression inside a call/new expression skip,
+            // this is to ensure that we consider the correct line length of the result.
             //
             // Example:
             //     ```ts
@@ -72,22 +72,32 @@ export const minChainedCallDepth = createRule({
             //     ```
             //     The replacement of this input should be `foo.bar();`, which has 10 character.
             //     Without this check it would consider the length up to `r`, which is 7.
-            if (node.type === 'MemberExpression' && node.parent?.type === 'CallExpression') {
+            if (
+                node.type === AST_NODE_TYPES.MemberExpression
+                && node.parent?.type === AST_NODE_TYPES.CallExpression
+            ) {
                 return;
             }
 
-            // If the node is a call expression we need to validate it's callee as a member
+            // If the node is a call/new expression we need to validate it's callee as a member
             // expression.
             // If the node itself is already a member expression, like the
             // `property` in `this.property.function()`, we validate the node directly.
-            const callee = node.type === 'CallExpression' ? node.callee : node;
+            const callee = node.type === AST_NODE_TYPES.CallExpression
+                ? node.callee
+                : node;
 
             if (
                 // If the callee is not a member expression, we can skip.
                 // For example, root level calls like `foo();`.
-                callee.type !== 'MemberExpression'
+                callee.type !== AST_NODE_TYPES.MemberExpression
                 // If the callee is a computed member expression, like `foo[bar]()`, we can skip.
                 || callee.computed
+                /* eslint-disable-next-line @typescript-eslint/ban-ts-comment --
+                * NewExpression is a possible callee object type
+                */
+                // @ts-ignore
+                || callee.object.type === AST_NODE_TYPES.NewExpression
                 // If the callee is already in the same line as it's object, we can skip.
                 || callee.object.loc.end.line === callee.property.loc.start.line
             ) {
@@ -109,7 +119,7 @@ export const minChainedCallDepth = createRule({
             const semicolon = sourceCode.getLastToken(node.parent!, {
                 filter: token => (
                     token.loc.start.line === property.loc.start.line
-                    && token.type === 'Punctuator'
+                    && token.type === AST_TOKEN_TYPES.Punctuator
                     && token.value === ';'
                 ),
             });

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -25,7 +25,7 @@ export const minChainedCallDepth = createRule({
                         minimum: 1,
                         default: 100,
                     },
-                    ignoreChainWithDepth: {
+                    ignoreChainDeeperThan: {
                         type: 'integer',
                         minimum: 1,
                         maximum: 10,
@@ -44,7 +44,7 @@ export const minChainedCallDepth = createRule({
             maxLineLength: 100,
         },
         {
-            ignoreChainWithDepth: 2,
+            ignoreChainDeeperThan: 3,
         },
     ],
     create: context => {
@@ -124,9 +124,9 @@ export const minChainedCallDepth = createRule({
                 return;
             }
 
-            const {maxLineLength = 100, ignoreChainWithDepth = 2} = context.options[0] ?? {};
+            const {maxLineLength = 100, ignoreChainDeeperThan = 2} = context.options[0] ?? {};
 
-            // If the max depth is greater than ignoreChainWithDepth, we can skip.
+            // If the max depth is greater than ignoreChainDeeperThan, we can skip.
             //
             // Example:
             //     ```ts
@@ -135,9 +135,9 @@ export const minChainedCallDepth = createRule({
             //         .map(x => x + 1)
             //         .slice(0, 5);
             //     ```
-            //     In this case the depth is 3, and the default value of ignoreChainWithDepth is 2.
+            //     In this case the depth is 3, and the default value of ignoreChainDeeperThan is 2.
             //     So the check can be skipped.
-            if (maxDepth > ignoreChainWithDepth) {
+            if (maxDepth > ignoreChainDeeperThan) {
                 return;
             }
 

--- a/src/rules/newline-per-chained-call/index.test.ts
+++ b/src/rules/newline-per-chained-call/index.test.ts
@@ -32,7 +32,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
             code: 'const a = m1().m2.m3().m4;',
             options: [
                 {
-                    ignoreChainWithDepth: 4,
+                    ignoreChainDeeperThan: 4,
                 },
             ],
         },
@@ -40,7 +40,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
             code: 'const a = m1().m2.m3().m4.m5().m6.m7().m8.m9();',
             options: [
                 {
-                    ignoreChainWithDepth: 8,
+                    ignoreChainDeeperThan: 8,
                 },
             ],
         },
@@ -183,7 +183,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
             output: 'const a = m1()\n.m2\n.m3()\n.m4()\n.m5()\n.m6()\n.m7();',
             options: [
                 {
-                    ignoreChainWithDepth: 3,
+                    ignoreChainDeeperThan: 3,
                 },
             ],
             errors: [
@@ -219,7 +219,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
             output: '(foo).bar()\n.biz()',
             options: [
                 {
-                    ignoreChainWithDepth: 1,
+                    ignoreChainDeeperThan: 1,
                 },
             ],
             errors: [
@@ -235,7 +235,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
             output: 'foo.bar()\n. /* comment */ biz()',
             options: [
                 {
-                    ignoreChainWithDepth: 1,
+                    ignoreChainDeeperThan: 1,
                 },
             ],
             errors: [
@@ -251,7 +251,7 @@ ruleTester.run('newline-per-chained-call', newlinePerChainedCall, {
             output: 'foo.bar() /* comment */ \n.biz()',
             options: [
                 {
-                    ignoreChainWithDepth: 1,
+                    ignoreChainDeeperThan: 1,
                 },
             ],
             errors: [

--- a/src/rules/newline-per-chained-call/index.ts
+++ b/src/rules/newline-per-chained-call/index.ts
@@ -21,7 +21,7 @@ export const newlinePerChainedCall = createRule({
             {
                 type: 'object',
                 properties: {
-                    ignoreChainWithDepth: {
+                    ignoreChainDeeperThan: {
                         type: 'integer',
                         minimum: 1,
                         maximum: 10,
@@ -37,12 +37,12 @@ export const newlinePerChainedCall = createRule({
     },
     defaultOptions: [
         {
-            ignoreChainWithDepth: 2,
+            ignoreChainDeeperThan: 2,
         },
     ],
     create: context => {
         const options = context.options[0] ?? {};
-        const ignoreChainWithDepth = options.ignoreChainWithDepth ?? 2;
+        const ignoreChainWithDepth = options.ignoreChainDeeperThan ?? 2;
 
         const sourceCode = context.getSourceCode();
 


### PR DESCRIPTION
## Summary

This pull request aims to fix some conflicts between `min-chained-call-depth` and `newline-per-chained-call`.

* Added a new option to the `min-chained-call-depth` called `ignoreChainWithDepth`, which has on purpose the same name as in the`newline-per-chained-call`.

### Examples 
✅ Good
```ts
Array(10)
    .fill(10)
    .map(foo => foo)
    .slice(5);
```
```ts
Array(10).fill(10);
```

❌ Bad
```ts
Array(10)
    .map(foo => foo)
    .slice(5);
```
```ts
Array(10)
    .fill(10);
```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings