### PR TITLE
Add jsx-sort-props rule

### DIFF
--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -19,6 +19,12 @@ export const react = {
         '@croct/jsx-attribute-spacing': 'error',
         'react/jsx-wrap-multilines': 'error',
         'react/display-name': 'off',
+        'react/jsx-sort-props': [
+            'error',
+            {
+                multiline: 'last',
+            },
+        ],
         'jsx-quotes': [
             'error',
             'prefer-double',

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -22,6 +22,7 @@ export const react = {
         'react/jsx-sort-props': [
             'error',
             {
+                noSortAlphabetically: true,
                 multiline: 'last',
             },
         ],


### PR DESCRIPTION
## Summary

By adding the `jsx-sort-props` rule, the props will now be sorted by alphabetical order, and the multiline props will be automatically listed after all the other props.

Before, the following code would be consider valid:
```tsx
<Hello
  classes={{
    greetings: classes.greetings,
  }}
  active
  validate
  name="John"
  tel={5555555}
/>
```

Now, the same version but with `jsx-sort-props`:
```tsx
<Hello
  active
  validate
  name="John"
  tel={5555555}
  classes={{
    greetings: classes.greetings,
  }}
/>
```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings