### PR TITLE
Change maximum line length to 120

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -70,7 +70,7 @@ export const javascript = {
             'error',
             {
                 items: 6,
-                'max-len': 100,
+                'max-len': 120,
             },
         ],
         'no-smart-quotes/no-smart-quotes': 'error',
@@ -109,7 +109,7 @@ export const javascript = {
         'max-len': [
             'error',
             {
-                code: 100,
+                code: 120,
                 ignoreStrings: false,
                 ignoreComments: false,
                 ignoreTemplateLiterals: false,


### PR DESCRIPTION
## Summary

Our other languages (Java, PHP and Go) have a maximum line length of 120, this PR changes the configuration to match this pattern.