### PR TITLE
Fix padding-line to break before continue

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -204,6 +204,8 @@ export const javascript = {
                 blankLine: 'always',
                 prev: '*',
                 next: [
+                    'break',
+                    'continue',
                     'return',
                     'if',
                     'function',


### PR DESCRIPTION
## Summary

In Java and PHP it's required to break the line before the `continue` keyword. This PR fixes this behavior in Javascript.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings