### PR TITLE
Block unused disable directives

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -25,6 +25,7 @@ export const javascript = {
             },
         ],
         'eslint-comments/require-description': 'error',
+        'eslint-comments/no-unused-disable': 'error',
         'newline-per-chained-call': 'off',
         'no-plusplus': 'off',
         'array-bracket-newline': [

--- a/src/rules/argument-spacing/index.ts
+++ b/src/rules/argument-spacing/index.ts
@@ -1,8 +1,3 @@
-/*
-    eslint-disable @typescript-eslint/no-non-null-assertion
-    --
-    Disable the rule to reduce the number of branches
-*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {createRule} from '../createRule';
 

--- a/src/rules/complex-expression-spacing/index.ts
+++ b/src/rules/complex-expression-spacing/index.ts
@@ -1,8 +1,3 @@
-/*
-    eslint-disable @typescript-eslint/no-non-null-assertion
-    --
-    Disable the rule to reduce the number of branches
-*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {createRule} from '../createRule';
 

--- a/src/rules/jsx-attribute-spacing/index.ts
+++ b/src/rules/jsx-attribute-spacing/index.ts
@@ -1,8 +1,3 @@
-/*
-    eslint-disable @typescript-eslint/no-non-null-assertion
-    --
-    Disable the rule to reduce the number of branches
-*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {createRule} from '../createRule';
 

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -1,8 +1,3 @@
-/*
-    eslint-disable @typescript-eslint/no-non-null-assertion
-    --
-    Disable the rule to reduce the number of branches
-*/
 import {AST_TOKEN_TYPES, AST_NODE_TYPES, TSESTree} from '@typescript-eslint/experimental-utils';
 import {isCommentToken} from '@typescript-eslint/utils/dist/ast-utils';
 import {createRule} from '../createRule';

--- a/src/rules/newline-per-chained-call/index.ts
+++ b/src/rules/newline-per-chained-call/index.ts
@@ -1,8 +1,3 @@
-/*
-    eslint-disable @typescript-eslint/no-non-null-assertion
-    --
-    Disable the rule to reduce the number of branches
-*/
 import {TSESTree} from '@typescript-eslint/experimental-utils';
 import {createRule} from '../createRule';
 

--- a/src/rules/parameter-destructuring/index.ts
+++ b/src/rules/parameter-destructuring/index.ts
@@ -1,8 +1,3 @@
-/*
- eslint-disable @typescript-eslint/no-non-null-assertion
- --
- Disable the rule to reduce the number of branches
- */
 import {AST_NODE_TYPES} from '@typescript-eslint/types';
 import {RuleFix} from '@typescript-eslint/utils/dist/ts-eslint';
 import {createRule} from '../createRule';


### PR DESCRIPTION
## Summary

Enable the [`no-unused-disable`](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html) rule from `esline-comments`.

This rule flags unnecessary `eslint-disable` directives as errors, ensuring that any such directive is removed once they are no longer necessary.

Since this is a rule with full auto-fix, I don't think this needs to be a breaking change
