### PR TITLE
Disable no-use-before-define for functions declarations

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -77,7 +77,12 @@ export const javascript = {
         'no-shadow': 'error',
         'import/prefer-default-export': 'off',
         'import/no-extraneous-dependencies': 'off',
-        'no-use-before-define': 'error',
+        'no-use-before-define': [
+            'error',
+            {
+                functions: false,
+            },
+        ],
         'arrow-parens': [
             'error',
             'as-needed',

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -37,7 +37,12 @@ export const typescript = {
                 '@typescript-eslint/explicit-function-return-type': ['error'],
                 '@typescript-eslint/no-explicit-any': 'off',
                 'no-use-before-define': 'off',
-                '@typescript-eslint/no-use-before-define': 'error',
+                '@typescript-eslint/no-use-before-define': [
+                    'error',
+                    {
+                        functions: false,
+                    },
+                ],
                 'no-unused-expressions': 'off',
                 '@typescript-eslint/no-unused-expressions': 'error',
                 indent: ['error', 4, {


### PR DESCRIPTION
## Summary

This PR disables the lint `no-use-before-define` for function declarations, as sometimes we wish to declare the file structure following the dependency flow.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings