### PR TITLE
Move the jsx-quotes to javascript config

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -229,6 +229,10 @@ export const javascript = {
                 items: Infinity,
             },
         ],
+        'jsx-quotes': [
+            'error',
+            'prefer-double',
+        ],
     },
     overrides: [
         {

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -219,6 +219,15 @@ export const javascript = {
                     'block-like',
                 ],
             },
+            {
+                blankLine: 'any',
+                prev: [
+                    'case',
+                ],
+                next: [
+                    'case',
+                ],
+            },
         ],
         'no-useless-escape': 'error',
         'newline-destructuring/newline': [

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -27,10 +27,6 @@ export const react = {
                 multiline: 'last',
             },
         ],
-        'jsx-quotes': [
-            'error',
-            'prefer-double',
-        ],
         'react/jsx-newline': [
             'error',
             {


### PR DESCRIPTION
## Summary

This PR moves `jsx-quotes` to the javascript config as it wasn't working inside the react config.

Result applying in one of our projects
![image](https://user-images.githubusercontent.com/23644327/225904450-a5934654-3db2-4009-9120-d0853a9cdcd5.png)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings