### PR TITLE
Disable @typescript-eslint/no-use-before-define rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -37,12 +37,7 @@ export const typescript = {
                 '@typescript-eslint/explicit-function-return-type': ['error'],
                 '@typescript-eslint/no-explicit-any': 'off',
                 'no-use-before-define': 'off',
-                '@typescript-eslint/no-use-before-define': [
-                    'error',
-                    {
-                        functions: false,
-                    },
-                ],
+                '@typescript-eslint/no-use-before-define': 'off',
                 'no-unused-expressions': 'off',
                 '@typescript-eslint/no-unused-expressions': 'error',
                 indent: ['error', 4, {


### PR DESCRIPTION
## Summary

This PR disables the `@typescript-eslint/no-use-before-define` rule as stated by @marcospassos in another repo:

> In JavaScript, prior to ES6, variable and function declarations are hoisted to the top of a scope, so it’s possible to use identifiers before their formal declarations in code. This can be confusing and some believe it is best to always declare variables and functions before using them.
> 
> In ES6, block-level bindings (let and const) introduce a “temporal dead zone” where a ReferenceError will be thrown with any attempt to access the variable before its declaration.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings