### PR TITLE
Relax unbound method rule

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -33,7 +33,6 @@ jobs:
         run: |-
           cp package.json LICENSE README.md dist/
           cd dist
-          sed -i -e "s~\"version\": \"0.0.0-dev\"~\"version\": \"${GITHUB_REF##*/}\"~" package.json
           sed -i -e "s~\"main\": \"dist/index.js\"~\"main\": \"index.js\"~" package.json
           sed -i -e "s~\"types\": \"dist/index.d.ts\"~\"types\": \"index.d.ts\"~" package.json
 

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,44 @@
+name: PR preview
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Prepare release
+        run: |-
+          cp package.json LICENSE README.md dist/
+          cd dist
+          sed -i -e "s~\"version\": \"0.0.0-dev\"~\"version\": \"${GITHUB_REF##*/}\"~" package.json
+          sed -i -e "s~\"main\": \"dist/index.js\"~\"main\": \"index.js\"~" package.json
+          sed -i -e "s~\"types\": \"dist/index.d.ts\"~\"types\": \"index.d.ts\"~" package.json
+
+      - name: Publish preview
+        run: |-
+          npx pkg-pr-new publish \
+            --compact --comment=update \
+            ./dist

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -10,14 +10,14 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('**/package-lock.json') }}

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -111,5 +111,13 @@ export function createTypescriptConfig(plugin: ESLint.Plugin, javascriptConfig: 
             },
             rules: baseRules,
         },
+        {
+            name: '@croct/typescript-test-files',
+            files: ['**/*.test.ts', '**/*.test.tsx'],
+            rules: {
+                // Prevent false warning when checking mocked interfaces
+                '@typescript-eslint/unbound-method': 'off',
+            },
+        },
     ];
 }

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -115,7 +115,7 @@ export function createTypescriptConfig(plugin: ESLint.Plugin, javascriptConfig: 
             name: '@croct/typescript-test-files',
             files: ['**/*.test.ts', '**/*.test.tsx'],
             rules: {
-                // Prevent false warning when checking mocked interfaces
+                // Prevent false warnings when checking mocked interfaces
                 '@typescript-eslint/unbound-method': 'off',
             },
         },


### PR DESCRIPTION
## Summary

Allow unbound methods on tests. Otherwise this common pattern is flagged:
```ts
const mockedThing: ThingInterface = {
  someMethod: jest.fn(),
  otherMethod: jest.fn(),
};

// Test some function or class that takes a `ThingInterface`

// Use of unbound method since the type annotation erased
// the information that it is not an instance.
expect(mockedThing.someMethod).toHaveBeenCalledOnceWith(...);
```