### PR TITLE
Add consistent type imports rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -71,6 +71,7 @@ const baseRules: Linter.RulesRecord = {
     'no-undef': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/restrict-template-expressions': 'off',
+    '@typescript-eslint/consistent-type-imports': 'error',
 
     // Disable rules that turn `any` into `unknown`, places where `unknown` is the preferred type
     // have that type already.

--- a/src/rules/min-chained-call-depth/index.ts
+++ b/src/rules/min-chained-call-depth/index.ts
@@ -1,4 +1,5 @@
-import {AST_TOKEN_TYPES, AST_NODE_TYPES, TSESTree} from '@typescript-eslint/utils';
+import type {TSESTree} from '@typescript-eslint/utils';
+import {AST_TOKEN_TYPES, AST_NODE_TYPES} from '@typescript-eslint/utils';
 import {isCommentToken} from '@typescript-eslint/utils/ast-utils';
 import {createRule} from '../createRule';
 

--- a/src/rules/parameter-destructuring/index.ts
+++ b/src/rules/parameter-destructuring/index.ts
@@ -1,5 +1,5 @@
 import {AST_NODE_TYPES} from '@typescript-eslint/utils';
-import {RuleFix} from '@typescript-eslint/utils/ts-eslint';
+import type {RuleFix} from '@typescript-eslint/utils/ts-eslint';
 import {createRule} from '../createRule';
 
 export const parameterDestructuring = createRule({


### PR DESCRIPTION
## Summary

Enable consistent type import rule. See https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/