### PR TITLE
Use jq in release prepare script

### DIFF
--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -13,6 +13,5 @@ jobs:
       prepare-script: >-
         cp package.json LICENSE README.md dist/ &&
         cd dist &&
-        sed -i -e "s~\"version\": \"0.0.0-dev\"~\"version\": \"${GITHUB_REF##*/}\"~" package.json &&
-        sed -i -e "s~\"main\": \"dist/index.js\"~\"main\": \"index.js\"~" package.json &&
-        sed -i -e "s~\"types\": \"dist/index.d.ts\"~\"types\": \"index.d.ts\"~" package.json
+        jq --arg version "${GITHUB_REF##*/}" '.version = $version | .main |= sub("^dist/"; "") | .types |= sub("^dist/"; "")' package.json > package.tmp.json &&
+        mv package.tmp.json package.json


### PR DESCRIPTION
## Summary

Update the release prepare script to mutate `package.json` with `jq` instead of brittle `sed` replacements.

## Changes

- Replace the three `sed` commands with a single `jq` expression.
- Set the package version from the release tag.
- Strip the leading `dist/` prefix from `main` and `types` in the copied package metadata.

## Testing

- Ran `git diff --check`.
- Runtime `jq` smoke test was not run because the environment blocked the command.
