### PR TITLE
Fix bundled plugin package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "eslint-plugin-self": "^1.2.1",
         "eslint-plugin-testing-library": "^7.16.2",
         "globals": "^17.6.0",
-        "typescript-eslint": "^8.59.4"
+        "typescript-eslint": "^8.59.4",
+        "unrs-resolver": "^1.12.2"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -6464,7 +6465,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
       "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "napi-postinstall": "lib/cli.js"
@@ -8519,7 +8519,6 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
       "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "eslint-plugin-self": "^1.2.1",
     "eslint-plugin-testing-library": "^7.16.2",
     "globals": "^17.6.0",
-    "typescript-eslint": "^8.59.4"
+    "typescript-eslint": "^8.59.4",
+    "unrs-resolver": "^1.12.2"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/src/bundle.test.ts
+++ b/src/bundle.test.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import {execFileSync} from 'node:child_process';
+
+const requireFromTest = createRequire(__filename);
+
+function buildBundle(): string {
+    execFileSync('npm', ['run', 'build'], {
+        cwd: path.resolve(__dirname, '..'),
+        stdio: 'pipe',
+    });
+
+    return path.resolve(__dirname, '../dist/index.cjs');
+}
+
+describe('published bundle', () => {
+    it('inlines metadata for bundled plugins that read their own package.json', () => {
+        const bundlePath = buildBundle();
+        const bundle = fs.readFileSync(bundlePath, 'utf8');
+
+        expect(bundle).not.toContain('cjsRequire("../package.json")');
+
+        const sandboxRoot = path.resolve(__dirname, '../.tmp');
+
+        fs.mkdirSync(sandboxRoot, {recursive: true});
+
+        const sandbox = fs.mkdtempSync(path.join(sandboxRoot, 'croct-eslint-plugin-'));
+        const packageDir = path.join(sandbox, 'node_modules/@croct/eslint-plugin');
+        const distDir = path.join(packageDir, 'dist');
+
+        fs.mkdirSync(distDir, {recursive: true});
+        fs.copyFileSync(bundlePath, path.join(distDir, 'index.cjs'));
+        fs.writeFileSync(
+            path.join(packageDir, 'package.json'),
+            JSON.stringify({name: '@croct/eslint-plugin', version: '0.0.0-dev', main: 'dist/index.cjs'}),
+        );
+
+        const script = [
+            `const plugin = require(${JSON.stringify(packageDir)});`,
+            'const javascriptConfig = plugin.configs.javascript.at(-1);',
+            'process.stdout.write(JSON.stringify(javascriptConfig.plugins[\'import-x\'].meta));',
+        ].join('\n');
+
+        const meta = execFileSync(
+            'node',
+            ['-e', script],
+            {cwd: path.resolve(__dirname, '..'), encoding: 'utf8'},
+        );
+
+        const importXPackageJson = JSON.parse(
+            fs.readFileSync(requireFromTest.resolve('eslint-plugin-import-x/package.json'), 'utf8'),
+        ) as {name: string, version: string};
+
+        expect(JSON.parse(meta)).toEqual({
+            name: importXPackageJson.name,
+            version: importXPackageJson.version,
+        });
+    });
+});

--- a/tsdown.config.mts
+++ b/tsdown.config.mts
@@ -1,11 +1,115 @@
 import { defineConfig } from 'tsdown';
+import fs from 'node:fs';
 import path from 'node:path';
+import {parseAst} from 'rolldown/parseAst';
+
+type AstNode = {
+    type?: string;
+    start?: number;
+    end?: number;
+    name?: string;
+    value?: unknown;
+    callee?: AstNode;
+    arguments?: AstNode[];
+    [key: string]: unknown;
+};
+
+type Replacement = {
+    start: number;
+    end: number;
+    value: string;
+};
+
+function isNode(value: unknown): value is AstNode {
+    return typeof value === 'object' && value !== null && typeof (value as AstNode).type === 'string';
+}
+
+function isNodeArray(value: unknown): value is AstNode[] {
+    return Array.isArray(value) && value.every(isNode);
+}
+
+function isBundledDependency(id: string): boolean {
+    return id.includes('/node_modules/') || id.includes('\\node_modules\\');
+}
+
+function isPackageJsonSpecifier(value: unknown): value is string {
+    return typeof value === 'string' && value.startsWith('.') && path.basename(value) === 'package.json';
+}
+
+function findPackageJsonRequires(node: AstNode, visitor: (node: AstNode, specifier: string) => void): void {
+    if (
+        node.type === 'CallExpression'
+        && node.callee?.type === 'Identifier'
+        && (node.callee.name === 'cjsRequire' || node.callee.name === 'require')
+        && node.arguments?.length === 1
+        && node.arguments[0]?.type === 'Literal'
+        && isPackageJsonSpecifier(node.arguments[0].value)
+    ) {
+        visitor(node, node.arguments[0].value);
+    }
+
+    for (const value of Object.values(node)) {
+        if (isNode(value)) {
+            findPackageJsonRequires(value, visitor);
+        } else if (isNodeArray(value)) {
+            for (const child of value) {
+                findPackageJsonRequires(child, visitor);
+            }
+        }
+    }
+}
+
+function applyReplacements(code: string, replacements: Replacement[]): string {
+    return replacements
+        .sort((first, second) => second.start - first.start)
+        .reduce(
+            (result, replacement) => (
+                result.slice(0, replacement.start) + replacement.value + result.slice(replacement.end)
+            ),
+            code,
+        );
+}
+
+function inlineBundledPackageJson() {
+    return {
+        name: 'inline-bundled-package-json',
+        transform(code: string, id: string, meta: {ast?: AstNode} = {}) {
+            if (!isBundledDependency(id) || !code.includes('package.json')) {
+                return null;
+            }
+
+            const ast = meta.ast ?? parseAst(code, null, id) as AstNode;
+            const replacements: Replacement[] = [];
+
+            findPackageJsonRequires(ast, (node, specifier) => {
+                if (node.start === undefined || node.end === undefined) {
+                    return;
+                }
+
+                const packageJsonPath = path.resolve(path.dirname(id), specifier);
+
+                if (!fs.existsSync(packageJsonPath)) {
+                    return;
+                }
+
+                replacements.push({
+                    start: node.start,
+                    end: node.end,
+                    value: JSON.stringify(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))),
+                });
+            });
+
+            return replacements.length > 0 ? applyReplacements(code, replacements) : null;
+        },
+    };
+}
 
 export default defineConfig({
     entry: ['src/index.ts'],
     format: 'cjs',
     dts: true,
     platform: 'node',
+    plugins: [inlineBundledPackageJson()],
     alias: {
         // Redirect to a shim that statically resolves rules
         // (the original uses `requireindex` which breaks in bundles)


### PR DESCRIPTION
## Summary

Fix the published bundle so bundled plugin metadata is self-contained instead of resolving a sibling `package.json` at runtime. This prevents plugins like `eslint-plugin-import-x` from reading `@croct/eslint-plugin`'s package metadata, or failing when the expected package file is absent.

## Changes

- Move `eslint-plugin-import-x` into runtime dependencies so the package graph matches the bundled code path.
- Add a tsdown/Rolldown plugin that uses the transform AST to inline relative `package.json` require calls from bundled dependencies.
- Add a regression test that builds the published bundle in an isolated package layout and verifies `import-x` metadata still points to `eslint-plugin-import-x`.

## Testing

- `npm run lint`
- `npm run validate`
- `npm test -- --runInBand`
